### PR TITLE
Issue 3: Draft PR 3+ Users

### DIFF
--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -1,11 +1,17 @@
 const { Op } = require("sequelize");
 const db = require("../db");
-const Message = require("./message");
+const User = require("./user");
+const Participant = require("./participant");
+const Sequelize = require("sequelize");
 
-const Conversation = db.define("conversation", {});
+const Conversation = db.define("conversation", { 
+  nickname: {
+    type: Sequelize.STRING,
+    allowNull: true,
+  } 
+},{ userId: false });
 
-// find conversation given two user Ids
-
+// (v1) find conversation given two user Ids
 Conversation.findConversation = async function (user1Id, user2Id) {
   const conversation = await Conversation.findOne({
     where: {
@@ -14,8 +20,82 @@ Conversation.findConversation = async function (user1Id, user2Id) {
       },
       user2Id: {
         [Op.or]: [user1Id, user2Id]
-      }
+      },
     }
+  });
+
+  // return conversation or null if it doesn't exist
+  return conversation;
+};
+
+// (v2) : get conversation by conversationId
+Conversation.findConversationById = async function (conversationId) {
+  const conversation = await Conversation.findOne({
+    where: {
+      id: conversationId 
+    }
+  });
+
+  // return conversation or null if it doesn't exist
+  return conversation;
+};
+
+// (v2) : get conversation by conversationId and participant userId
+Conversation.findConversationByIdAndUserId = async function (conversationId, userId) {
+  const conversation = await Conversation.findOne({
+    where: {
+      id: conversationId
+    },
+    include: [
+      {
+        model: Participant,
+        where: {
+          userId: userId
+        },
+        required: true
+
+      }
+    ],
+    attributes: ["id"]
+  });
+
+  // return conversation or null if it doesn't exist
+  return conversation;
+};
+
+// (v2) find conversation by conversation nickname or name of user in conversation
+Conversation.findConversationBySearchTerm = async function (searchTerm) {
+  const conversation = await Conversation.findAll({
+    include: [
+      { 
+        model: User,
+        as: "filterUser",
+        where: {
+          [Op.or]: [
+            {
+              username: {
+                [Op.iLike]: `%${searchTerm}%`
+              }
+            },
+            {
+              '$conversation.nickname$' : {
+                [Op.iLike]: `%${searchTerm}%`
+              } 
+            }
+          ]
+        },
+        attributes: [] 
+      },
+      { 
+        model: User,
+        through: {
+            attributes: []
+        },
+        attributes: ["id","username", "photoUrl"] 
+      }
+    ],
+    attributes: ["id", "nickname"],
+    required: true
   });
 
   // return conversation or null if it doesn't exist

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,17 +1,20 @@
 const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
+const Participant = require("./participant");
 
 // associations
 
-User.hasMany(Conversation);
-Conversation.belongsTo(User, { as: "user1" });
-Conversation.belongsTo(User, { as: "user2" });
-Message.belongsTo(Conversation);
+Conversation.belongsToMany(User, { through: Participant });
+Conversation.belongsToMany(User, {through: Participant, as: 'filterUser'});
 Conversation.hasMany(Message);
+Conversation.hasMany(Participant);
+Message.belongsTo(Conversation);
+Message.hasMany(Participant, { foreignKey: "lastRead" });
 
 module.exports = {
   User,
   Conversation,
   Message,
+  Participant
 };

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -10,6 +10,11 @@ const Message = db.define("message", {
     type: Sequelize.INTEGER,
     allowNull: false,
   },
+  read: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  }
 });
 
 module.exports = Message;

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -10,11 +10,6 @@ const Message = db.define("message", {
     type: Sequelize.INTEGER,
     allowNull: false,
   },
-  read: {
-    type: Sequelize.BOOLEAN,
-    allowNull: false,
-    defaultValue: false
-  }
 });
 
 module.exports = Message;

--- a/server/db/models/participant.js
+++ b/server/db/models/participant.js
@@ -1,0 +1,30 @@
+const db = require("../db");
+
+const Participant = db.define("participant", {});
+
+// find partipant given a conversationId and userId
+Participant.findActiveParticipant = async function (conversationId, userId) {
+  const participant = await Participant.findOne({
+    where: {
+      conversationId,
+      userId,
+    }
+  });
+
+  // return participant or null if it doesn't exist
+  return participant;
+};
+
+// find conversation given conversationId
+Participant.findActiveParticipantsByConversationId = async function (conversationId) {
+  const participants = await Participant.findAll({
+    where: {
+      conversationId,
+    }
+  });
+
+  // return conversation or null if it doesn't exist
+  return participants;
+};
+
+module.exports = Participant;


### PR DESCRIPTION
## Issue 3: Draft PR 3+ Users
Fixes: #3 

### 1. Additional Changes Needed

#### SEED DB:
  + Add new participant record for each user in each current conversation.
  + Calculate lastRead message for each user in each conversation and update participant data model.

#### UPDATE API
  + Versioning the API (v1, v2)
  + Conversations Endpoints => users1Id/user2Id will become to participants, otherUser will become otherUsers array (list), and add functionality to update optional conversation nickname
  + Messages Endpoints => Require conversationId and check if sender is apart of conversation before adding message using Conversation.findConversationByIdAndUserId. If conversationId null: create conversation, and add participants upon creating new conversation.

#### UTILS
  + thunkCreator/reducerFunctions => anything with recipientId will need to be updated to Array (otherUsers/participants) (ex. addNewConversation and addNewConvoToStore)
  + Will need to create new functions to update otherUsers/participants in store when adding new users to conversation.

#### COMPONENTS 
  + Sidebar => Conversations in sidebar will need to display conversation nickname by default or concatenate names of participants if no nickname exists.
  + Search for Conversations => will now use Conversation.findConversationBySearchTerm: (this checks search term against conversations nicknames or user's usernames within conversation)
  + Need to add feature for adding blank conversation in memory, then searching for and adding users to blank conversation before sending new message. 

### 2.  Migrating Production
 Assuming this project was deployed in production and had multiple interfaces like a desktop app, iOS app, android etc.:
  + The current database would need to be updated and include the new data model for participants. 
  + The participants data model would need to be seeded as explained above in Q1 (SEED DB).  
  + Versioning the API to include new functions via api/v2/[endpoints] would help tremendously, especially if the app had a desktop, iOS, or android component.
  + You could likely keep the current structure in conversations data model (user1Id and user2Id) until the other apps were updated, eventually removing user1Id and user2Id.
  
Thanks for reviewing my initial ideas on adding 3+ person conversations to the messenger chat app. I invite you to discuss and help expand this further!